### PR TITLE
add: IPv6 support

### DIFF
--- a/OpenSpeedTest-Server.conf
+++ b/OpenSpeedTest-Server.conf
@@ -23,6 +23,8 @@ server {
 server_name _ localhost;
         listen 3000;
         listen 3001 ssl; # HTTP2 Disabled because of Performance issues.
+        listen [::]:3000;
+        listen [::]:3001 ssl; # HTTP2 Disabled because of Performance issues.
         # If you like to Ebable HTTP2 add "http2" to the above line.
         # If HTTP2 Enabled Upload location should Proxy_Pass to http port.
         # Otherwise you will see abnormal Upload Speeds.


### PR DESCRIPTION
It is noticed that servers deployed via docker image lack IPv6 support. After inspecting the nginx configuration file, it is believed that the config file is not prepared for IPv6 yet.

```
        listen 3000;
        listen 3001 ssl; # HTTP2 Disabled because of Performance issues.
```

This pull request have the problem fixed by listening to `[::]`. It should now be accessible over IPv6.

```
        listen 3000;
        listen 3001 ssl; # HTTP2 Disabled because of Performance issues.
+++     listen [::]:3000;
+++     listen [::]:3001 ssl; # HTTP2 Disabled because of Performance issues.
```
